### PR TITLE
Make the Privacy Note a Modal + Validate the checkbox

### DIFF
--- a/src/hooks/useFormField.js
+++ b/src/hooks/useFormField.js
@@ -10,7 +10,13 @@ export default function useFormField(initialState) {
   const [currentState, setState] = useState(initialState);
 
   function handleInputChange(e) {
-    setState(e.target.value);
+    switch (e.target.type) {
+      case "checkbox":
+        setState(e.target.checked);
+        break;
+      default:
+        setState(e.target.value);
+    }
   }
 
   function resetInputState() {

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -66,7 +66,7 @@ let strings = new LocalizedStrings(
       //CreateAccount
       nameIsRequired: "Name is required.",
       passwordMustBeMsg: "Password should be at least 4 characters long.",
-      passwordMustBeMsg: "You need to agree to our privacy notice.",
+      plsAcceptPrivacyPolicy: "You need to agree to our privacy notice.",
       thankYouMsgPrefix:
         "Thanks for being a beta-tester. We really want to hear from you at",
       thankYouMsgSuffix: ". Contact us also if you don't have an invite code.",

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -66,6 +66,7 @@ let strings = new LocalizedStrings(
       //CreateAccount
       nameIsRequired: "Name is required.",
       passwordMustBeMsg: "Password should be at least 4 characters long.",
+      passwordMustBeMsg: "You need to agree to our privacy notice.",
       thankYouMsgPrefix:
         "Thanks for being a beta-tester. We really want to hear from you at",
       thankYouMsgSuffix: ". Contact us also if you don't have an invite code.",

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -57,7 +57,7 @@ export default function CreateAccount({
     [name === "", strings.nameIsRequired],
     [!EmailValidator.validate(email), strings.plsProvideValidEmail],
     [password.length < 4, strings.passwordMustBeMsg],
-    [!checkPrivacyNote, strings.plsAcceptPrivacyNotice],
+    [!checkPrivacyNote, strings.plsAcceptPrivacyPolicy],
   ];
 
   useState(() => {

--- a/src/pages/CreateAccount.js
+++ b/src/pages/CreateAccount.js
@@ -1,7 +1,7 @@
 import { useState, useContext } from "react";
 
 import redirect from "../utils/routing/routing";
-import { isMobile } from "../utils/misc/browserDetection";
+import * as sC from "../components/modal_shared/Checkbox.sc";
 import useFormField from "../hooks/useFormField";
 
 import { UserContext } from "../contexts/UserContext";
@@ -19,7 +19,7 @@ import Footer from "./info_page_shared/Footer";
 import ButtonContainer from "./info_page_shared/ButtonContainer";
 import Button from "./info_page_shared/Button";
 import Checkbox from "../components/modal_shared/Checkbox";
-
+import Modal from "../components/modal_shared/Modal";
 import validator from "../assorted/validator";
 import strings from "../i18n/definitions";
 
@@ -45,21 +45,34 @@ export default function CreateAccount({
   const [name, handleNameChange] = useFormField("");
   const [email, handleEmailChange] = useFormField("");
   const [password, handlePasswordChange] = useFormField("");
+  const [checkPrivacyNote, handleCheckPrivacyNote] = useFormField(false);
 
   const [isPrivacyNoticeAccepted, setIsPrivacyNoticeAccepted] = useState(false);
 
   const [errorMessage, setErrorMessage] = useState("");
+  const [showPrivacyNotice, setShowPrivacyNotice] = useState(false);
+  const [privacyNoticeText, setPrivacyNoticeText] = useState([]);
 
   let validatorRules = [
     [name === "", strings.nameIsRequired],
     [!EmailValidator.validate(email), strings.plsProvideValidEmail],
     [password.length < 4, strings.passwordMustBeMsg],
-    [isPrivacyNoticeAccepted === false, strings.plsAcceptPrivacyNotice],
+    [!checkPrivacyNote, strings.plsAcceptPrivacyNotice],
   ];
 
-  function togglePrivacyNoticeConsent() {
-    setIsPrivacyNoticeAccepted((prev) => !prev);
-  }
+  useState(() => {
+    fetch(
+      "https://raw.githubusercontent.com/zeeguu/browser-extension/main/PRIVACY.md",
+    ).then((response) => {
+      response.text().then((privacyText) => {
+        let text = privacyText
+          .split("==============")[1]
+          .split("\n\n")
+          .filter((text) => text !== "");
+        setPrivacyNoticeText(text);
+      });
+    });
+  }, []);
 
   function handleCreate(e) {
     e.preventDefault();
@@ -97,6 +110,22 @@ export default function CreateAccount({
 
   return (
     <InfoPage type={"narrow"}>
+      <Modal
+        open={showPrivacyNotice}
+        onClose={() => {
+          setShowPrivacyNotice(false);
+        }}
+      >
+        <>
+          <h1>Privacy Notice</h1>
+          {privacyNoticeText.map((par) => (
+            <>
+              <p>{par}</p>
+              <br></br>
+            </>
+          ))}
+        </>
+      </Modal>
       <Header>
         <Heading>Create Beta&nbsp;Account</Heading>
       </Header>
@@ -154,23 +183,26 @@ export default function CreateAccount({
             />
           </FormSection>
           <FormSection>
-            <Checkbox
-              checked={isPrivacyNoticeAccepted}
-              onChange={togglePrivacyNoticeConsent}
-              label={
-                <>
-                  By checking this box you agree to our{" "}
-                  <a
-                    className="bold underlined-link"
-                    href="https://raw.githubusercontent.com/zeeguu/browser-extension/main/PRIVACY.md"
-                    target={isMobile() ? "_self" : "_blank"}
-                    rel="noreferrer"
-                  >
-                    {strings.privacyNotice}
-                  </a>
-                </>
-              }
-            />
+            <sC.CheckboxWrapper>
+              <input
+                onChange={handleCheckPrivacyNote}
+                checked={checkPrivacyNote}
+                id="checkbox"
+                name=""
+                value=""
+                type="checkbox"
+              ></input>
+              <label>
+                By checking this box you agree to our &nbsp;
+                <a
+                  onClick={() => {
+                    setShowPrivacyNotice(true);
+                  }}
+                >
+                  {strings.privacyNotice}
+                </a>
+              </label>
+            </sC.CheckboxWrapper>
           </FormSection>
         </Form>
       </Main>


### PR DESCRIPTION
Moved the Privacy Note inside a Modal and handled validation of the checkbox, not allowing the user to create an account if the checkbox is not checked. 